### PR TITLE
feat: add wechat article about Claude + domestic coding plan workflow

### DIFF
--- a/src/content/wechat/claude-plus-domestic-model-workflow.md
+++ b/src/content/wechat/claude-plus-domestic-model-workflow.md
@@ -1,0 +1,22 @@
+---
+title: 以后大部分程序员的 Coding 订阅，可能开两个就够了
+description: $20 的 Claude Pro 加国内 40 块的 Coding Plan，一个月不到 180 块。Claude 负责 spec、plan、review，国产模型比如 Kimi 负责跑实现。分工清晰，额度各司其职，比单靠一个工具更省钱也更顺手。
+pubDatetime: 2026-04-24T00:00:00Z
+tags: ["AI编程", "Claude", "Kimi", "工作流", "编程效率"]
+---
+
+感觉以后大部分程序员的 Coding 订阅，可能开两个就够了。
+
+一个是 $20 的 Claude Pro，另一个是国内 40 块钱左右的 Coding Plan，比如 Kimi 这种。加起来一个月不到 180，很实惠。
+
+Claude 负责 spec/plan/review，国产模型负责干活。
+
+每次来了个大需求，先开一个新分支，让 Claude 生成一份完整的 spec。这份 spec 通常会拆成一个或多个 plan，每个 plan 里有若干具体任务。每个任务要写清楚：最小实现代码是什么，怎么测试，怎么验收。
+
+然后把这些 plan 使用 Kimi K2.6 之类的国产模型进行实现。等整体实现结束，再让 Claude 做一轮 review，觉得没问题了提 PR。
+
+整个链路下来，Claude 的额度用在刀刃上，国产模型把量大的工作消化掉，两边各司其职。
+
+等我的 cursor 订阅结束了之后，就打算找一个合适的国产的 coding plan。
+
+#全栈成长之路


### PR DESCRIPTION
## Summary

新增一篇公众号图文，聊程序员 AI 编程订阅的性价比方案：Claude Pro 负责 spec/plan/review，国产模型（如 Kimi）负责实现，两边各司其职。

## Changes

- add `src/content/wechat/claude-plus-domestic-model-workflow.md`

## Notes

- 文章遵循 `wechat-graphic-message` skill 写作规范
- 正文约 196 字，结尾带 #全栈成长之路
- 未在 main 上直接操作